### PR TITLE
replace circleci config w/ template boilerplate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,240 +1,83 @@
 version: 2.1
 
 orbs:
-  artifactory: jfrog/artifactory@dev:alpha
-  orb-tools: circleci/orb-tools@8.9.2
+  # Replace this with your own!
+  npm: takescoop/artifactory@<<pipeline.parameters.dev-orb-version>>
+  orb-tools: circleci/orb-tools@10.0
+  bats: circleci/bats@1.0
+  shellcheck: circleci/shellcheck@2.0
+
+# Pipeline Parameters
+## These parameters are used internally by orb-tools. Skip to the Jobs section.
+parameters:
+  run-integration-tests:
+    description: An internal flag to prevent integration test from running before a development version has been created.
+    type: boolean
+    default: false
+  dev-orb-version:
+    description: >
+      The development version of the orb to test.
+      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
+      A "dev:alpha" version must exist for the initial pipeline run.
+    type: string
+    default: "dev:alpha"
 
 jobs:
-  all-commands:
-    executor: artifactory/machine
+  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  integration-test-1:
+    docker:
+      - image: cimg/base:stable
     steps:
       - checkout
-      - artifactory/install
-      - artifactory/configure
-
-      - run:
-          name: create sample artifact files
-          command: |
-            echo "not a jar" > artifact1.jar
-            echo "not a jar" > artifact2.jar
-
-      # test multiple files without spec
-      - artifactory/upload:
-          source: artifact*.jar
-          target: orb-testing/all-commands/no-file-spec/
-
-      # test with file spec
-      - artifactory/upload:
-          use-file-spec: true
-          file-spec: spec.json
-          spec-vars: spec-pattern=*.jar;spec-target=orb-testing/all-commands/file-spec/
-
-      - artifactory/build-integration
-
-      - artifactory/docker-login:
-          docker-registry: orbdemos-docker.jfrog.io
-
-      - run:
-          name: build sample image
-          command: |
-            docker build -t \
-              orbdemos-docker.jfrog.io/hello-world-default:1.0-${CIRCLE_BUILD_NUM} \
-              docker-publish-assets
-
-      - artifactory/docker-publish:
-          docker-tag: orbdemos-docker.jfrog.io/hello-world-default:1.0-${CIRCLE_BUILD_NUM}
-          repository: docker
-
-# yaml anchor filters
-integration-dev_filters: &integration-dev_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /integration-.*/
-
-integration-master_filters: &integration-master_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /master-.*/
-
-prod-deploy_requires: &prod-deploy_requires
-  [
-    test-all-commands-master,
-    test-upload-master,
-    test-publish-master,
-    test-publish-custom-master
-  ]
 
 workflows:
-  lint_pack-validate_publish-dev:
+  # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
+  # This workflow will run on every commit
+  test-pack:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint:
-          lint-dir: src
-
-      - orb-tools/pack:
+      - orb-tools/lint # Lint Yaml files
+      - orb-tools/pack # Pack orb source
+      # Publish development version(s) of the orb.
+      - orb-tools/publish-dev:
+          orb-name: takescoop/artifactory
+          context: orb-publish # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
           requires:
             - orb-tools/lint
-
-      - orb-tools/publish-dev:
-          orb-name: jfrog/artifactory
-          requires:
             - orb-tools/pack
-
-      - orb-tools/trigger-integration-workflow:
+      # Trigger an integration workflow to test the
+      # dev:${CIRCLE_SHA1:0:7} version of your orb
+      - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          ssh-fingerprints: # fill in your fingerprint here
-          cleanup-tags: true
+          context: orb-publish
           requires:
             - orb-tools/publish-dev
-          filters:
-            branches:
-              ignore: master
 
-      - orb-tools/trigger-integration-workflow:
-          name: trigger-integration-master
-          ssh-fingerprints: # fill in your fingerprint here
-          cleanup-tags: true
-          tag: master
-          requires:
-            - orb-tools/publish-dev
-          filters:
-            branches:
-              only: master
-
-  integration_tests-prod_deploy:
+  # This `integration-test_deploy` workflow will only run
+  # when the run-integration-tests pipeline parameter is set to true.
+  # It is meant to be triggered by the "trigger-integration-tests-workflow"
+  # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
+  integration-test_deploy:
+    when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      # triggered by non-master branch commits
-      - all-commands:
-          name: test-all-commands-dev
-          filters: *integration-dev_filters
-
-      - artifactory/upload:
-          name: test-upload-dev
-          source: artifact*.jar
-          target: orb-testing/upload-job/no-file-spec/
-          build-steps:
-            - run:
-                name: create sample artifact files
-                command: |
-                  echo "not a jar" > artifact1.jar
-                  echo "not a jar" > artifact2.jar
-          filters: *integration-dev_filters
-
-      - artifactory/upload:
-          name: test-upload-file-spec-dev
-          use-file-spec: true
-          file-spec: spec.json
-          spec-vars: spec-pattern=*.jar;spec-target=orb-testing/upload-job/file-spec/
-          build-steps:
-            - run:
-                name: create sample artifact files
-                command: |
-                  echo "not a jar" > artifact1.jar
-                  echo "not a jar" > artifact2.jar
-          filters: *integration-dev_filters
-
-      - artifactory/docker-publish:
-          name: test-publish-dev
-          docker-registry: orbdemos-docker.jfrog.io
-          repository: docker
-          build-name: hello-alpine
-          docker-tag: orbdemos-docker.jfrog.io/hello-world-default:1.0-${CIRCLE_BUILD_NUM}
-          pre-steps: [checkout, run: "cp docker-publish-assets/* ."]
-          filters: *integration-dev_filters
-
-      - artifactory/docker-publish:
-          name: test-publish-custom-dev
-          docker-registry: orbdemos-docker.jfrog.io
-          repository: docker
-          build-name: hello-alpine-custom
-          docker-tag: orbdemos-docker.jfrog.io/hello-alpine-custom:1.0-${CIRCLE_BUILD_NUM}
-          docker-steps:
-            - run: echo ${DOCKERTAG}
-            - run: jfrog rt dl local-generic/artifact.jar docker-publish-assets/ --build-name=hello-alpine-custom --build-number=${CIRCLE_BUILD_NUM}
-            - run: docker build -t $DOCKERTAG docker-publish-assets
-          filters: *integration-dev_filters
-
-      # triggered by master branch commits
-      - all-commands:
-          name: test-all-commands-master
-          filters: *integration-master_filters
-
-      - artifactory/upload:
-          name: test-upload-master
-          source: artifact*.jar
-          target: orb-testing/upload-job/no-file-spec/
-          build-steps:
-            - run:
-                name: create sample artifact files
-                command: |
-                  echo "not a jar" > artifact1.jar
-                  echo "not a jar" > artifact2.jar
-          filters: *integration-master_filters
-
-      - artifactory/upload:
-          name: test-upload-file-spec-master
-          use-file-spec: true
-          file-spec: spec.json
-          spec-vars: spec-pattern=*.jar;spec-target=orb-testing/upload-job/file-spec/
-          build-steps:
-            - run:
-                name: create sample artifact files
-                command: |
-                  echo "not a jar" > artifact1.jar
-                  echo "not a jar" > artifact2.jar
-          filters: *integration-master_filters
-
-      - artifactory/docker-publish:
-          name: test-publish-master
-          docker-registry: orbdemos-docker.jfrog.io
-          repository: docker
-          build-name: hello-alpine
-          docker-tag: orbdemos-docker.jfrog.io/hello-world-default:1.0-${CIRCLE_BUILD_NUM}
-          pre-steps: [checkout, run: "cp docker-publish-assets/* ."]
-          filters: *integration-master_filters
-
-      - artifactory/docker-publish:
-          name: test-publish-custom-master
-          docker-registry: orbdemos-docker.jfrog.io
-          repository: docker
-          build-name: hello-alpine-custom
-          docker-tag: orbdemos-docker.jfrog.io/hello-alpine-custom:1.0-${CIRCLE_BUILD_NUM}
-          docker-steps:
-            - run: echo ${DOCKERTAG}
-            - run: jfrog rt dl local-generic/artifact.jar docker-publish-assets/ --build-name=hello-alpine-custom --build-number=${CIRCLE_BUILD_NUM}
-            - run: docker build -t $DOCKERTAG docker-publish-assets
-          filters: *integration-master_filters
-
-      # patch, minor, or major publishing
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-patch
-          orb-name: jfrog/artifactory
-          requires: *prod-deploy_requires
+      # Run any integration tests defined within the `jobs` key.
+      - integration-test-1
+      # Publish a semver version of the orb. relies on
+      # the commit subject containing the text "[semver:patch|minor|major|skip]"
+      # as that will determine whether a patch, minor or major
+      # version will be published or if publishing should
+      # be skipped.
+      # e.g. [semver:patch] will cause a patch version to be published.
+      - orb-tools/dev-promote-prod-from-commit-subject:
+          orb-name: takescoop/artifactory
+          context: orb-publish
+          add-pr-comment: false
+          fail-if-semver-not-indicated: true
+          publish-version-tag: false
+          requires:
+            - integration-test-1
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /master-patch.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-minor
-          orb-name: jfrog/artifactory
-          release: minor
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-major
-          orb-name: jfrog/artifactory
-          release: major
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/
+              only:
+                - master
+                - main


### PR DESCRIPTION
Replaces the upstream config, which depends on Artifactory repositories we won't have access to, with a stripped down version of the boilerplate that `circleci orb init` generates. This effectively removes all tests, which is ok for now. Not super keen on setting up a bunch of test infrastructure to back this. If we were going to proceed with integration tests, I'd want to have CircleCI running Artifactory in a container rather than depend on a deployed instance with existing state. 