### PR TITLE
[semver:minor] promote: allow dependency-steps to be provided

### DIFF
--- a/src/jobs/docker-promote.yml
+++ b/src/jobs/docker-promote.yml
@@ -59,6 +59,13 @@ parameters:
     default: false
     description: >
       If set true, the Docker image is copied to the target repository, otherwise it is moved.
+  
+  dependency-steps:
+    type: steps
+    default: []
+    description: >
+      Include any additional steps to collect dependency information
+      before `jfrog rt dpr` is executed.
 
 executor: machine
 
@@ -70,6 +77,8 @@ steps:
       artifactory-url: <<parameters.artifactory-url>>
       artifactory-user: <<parameters.artifactory-user>>
       artifactory-key: <<parameters.artifactory-key>>
+
+  - steps: << parameters.dependency-steps >>
 
   - docker-promote:
       source-image: <<parameters.source-image>>

--- a/src/jobs/docker-promote.yml
+++ b/src/jobs/docker-promote.yml
@@ -59,7 +59,7 @@ parameters:
     default: false
     description: >
       If set true, the Docker image is copied to the target repository, otherwise it is moved.
-  
+
   dependency-steps:
     type: steps
     default: []


### PR DESCRIPTION
Allows callers of the `docker-promote` job to provide dependency steps, similar to the `docker-publish` job. This is useful when parameters for promotion are dynamic. For example, you might want to obtain a build ID from another command (or job) and add it to the bash environment for expansion during the call to `jfrog rt dpr`. 