### PR TITLE
Add Docker Layer Caching parameter for Docker publish job [semver:minor]

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -2,5 +2,12 @@ description: >
   A machine executor that can run Docker commands:
   https://circleci.com/docs/2.0/executor-types/#using-machine
 
+parameters:
+  docker-layer-caching:
+    type: boolean
+    default: false
+    description: "Enable Docker Layer Caching"
+
 machine:
   image: ubuntu-2004:202111-02
+  docker_layer_caching: <<parameters.docker-layer-caching>>

--- a/src/jobs/docker-publish.yml
+++ b/src/jobs/docker-publish.yml
@@ -82,8 +82,8 @@ parameters:
     description: "Enable Docker Layer Caching"
 
 executor:
-  <<: machine
-  docker_layer_caching: <<parameters.docker-layer-caching>>
+  name: machine
+  docker-layer-caching: <<parameters.docker-layer-caching>>
 
 environment:
   RAWTAG: <<parameters.docker-tag>>

--- a/src/jobs/docker-publish.yml
+++ b/src/jobs/docker-publish.yml
@@ -79,7 +79,7 @@ parameters:
   docker-layer-caching:
     type: boolean
     default: false
-    description: "Should Docker Layer Caching be enabled for this executor"
+    description: "Enable Docker Layer Caching"
 
 executor:
   <<: machine

--- a/src/jobs/docker-publish.yml
+++ b/src/jobs/docker-publish.yml
@@ -76,7 +76,14 @@ parameters:
       Include any additional steps to collect dependency information
       before `jfrog rt bp` is executed.
 
-executor: machine
+  docker-layer-caching:
+    type: boolean
+    default: false
+    description: "Should Docker Layer Caching be enabled for this executor"
+
+executor:
+  <<: machine
+  docker_layer_caching: <<parameters.docker-layer-caching>>
 
 environment:
   RAWTAG: <<parameters.docker-tag>>


### PR DESCRIPTION
### Context

Adds the `docker-layer-caching` parameter to `docker-publish`; the default is still `false`, but at least users can opt-in if they'd like

### Open Questions

- [ ] - Figure out if this will actually work, or not! I haven't tested and to be honest I'm not sure what the correct testing strategy is